### PR TITLE
Update permission requests based on latest capacitor documentation

### DIFF
--- a/android/src/main/java/io/radar/capacitor/RadarPlugin.java
+++ b/android/src/main/java/io/radar/capacitor/RadarPlugin.java
@@ -52,25 +52,25 @@ import io.radar.sdk.model.RadarUser;
         name = "Radar",
         permissions = {
                 @Permission(
-                        alias = "location",
+                        alias = RadarPlugin.LOCATION_PERMISSION,
                         strings = {
                                 Manifest.permission_group.LOCATION
                         }
                 ),
                 @Permission(
-                        alias = "backgroundLocation",
+                        alias = RadarPlugin.BACKGROUND_LOCATION_PERMISSION,
                         strings = {
                                 Manifest.permission.ACCESS_BACKGROUND_LOCATION
                         }
                 ),
                 @Permission(
-                        alias = "beacons",
+                        alias = RadarPlugin.BEACONS_PERMISSION,
                         strings = {
                                 Manifest.permission.ACCESS_FINE_LOCATION
                         }
                 ),
                 @Permission(
-                        alias = "beaconsAndroid12",
+                        alias = RadarPlugin.BEACONS_PERMISSIONS_ANDROID_12,
                         strings = {
                                 Manifest.permission.ACCESS_FINE_LOCATION,
                                 Manifest.permission.BLUETOOTH_SCAN
@@ -79,6 +79,11 @@ import io.radar.sdk.model.RadarUser;
         }
 )
 public class RadarPlugin extends Plugin {
+
+    static final String LOCATION_PERMISSION = "location";
+    static final String BACKGROUND_LOCATION_PERMISSION = "backgroundLocation";
+    static final String BEACONS_PERMISSION = "beacons";
+    static final String BEACONS_PERMISSIONS_ANDROID_12 = "beaconsAndroid12";
 
     private static final String TAG = "RadarPlugin";
     protected static RadarPlugin sPlugin;
@@ -217,7 +222,7 @@ public class RadarPlugin extends Plugin {
     public void getLocationPermissionsStatus(PluginCall call) {
         boolean foreground = false;
         String locationAuthorization = "NOT_DETERMINED";
-        PermissionState locationPermission = getPermissionState("location");
+        PermissionState locationPermission = getPermissionState(LOCATION_PERMISSION);
         if (PermissionState.GRANTED == locationPermission
                 || ContextCompat.checkSelfPermission(getContext(), Manifest.permission.ACCESS_FINE_LOCATION) == PackageManager.PERMISSION_GRANTED
                 || ContextCompat.checkSelfPermission(getContext(), Manifest.permission.ACCESS_COARSE_LOCATION) == PackageManager.PERMISSION_GRANTED
@@ -231,7 +236,7 @@ public class RadarPlugin extends Plugin {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             if (foreground) {
-                PermissionState backgroundState = getPermissionState("backgroundLocation");
+                PermissionState backgroundState = getPermissionState(BACKGROUND_LOCATION_PERMISSION);
                 if (PermissionState.GRANTED == backgroundState) {
                     locationAuthorization = "GRANTED_BACKGROUND";
                 }
@@ -247,9 +252,9 @@ public class RadarPlugin extends Plugin {
         String beaconsAuthorization = "NOT_DETERMINED";
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PermissionState beaconPermissions;
-            String alias = "beacons";
+            String alias = BEACONS_PERMISSION;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                alias = "beaconsAndroid12";
+                alias = BEACONS_PERMISSIONS_ANDROID_12;
             }
             beaconPermissions = getPermissionState(alias);
             if (PermissionState.GRANTED == beaconPermissions) {
@@ -273,16 +278,16 @@ public class RadarPlugin extends Plugin {
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PermissionState backgroundState = PermissionState.GRANTED;
-            PermissionState locationPermission = getPermissionState("location");
+            PermissionState locationPermission = getPermissionState(LOCATION_PERMISSION);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 if (Boolean.TRUE == background) {
-                    backgroundState = getPermissionState("backgroundLocation");
+                    backgroundState = getPermissionState(BACKGROUND_LOCATION_PERMISSION);
                 }
             }
             if (PermissionState.GRANTED != backgroundState) {
-                requestPermissionForAlias("backgroundLocation", call, "backgroundLocationPermsCallback");
+                requestPermissionForAlias(BACKGROUND_LOCATION_PERMISSION, call, "backgroundLocationPermsCallback");
             } else if (PermissionState.GRANTED != locationPermission) {
-                requestPermissionForAlias("location", call, "locationPermsCallback");
+                requestPermissionForAlias(LOCATION_PERMISSION, call, "locationPermsCallback");
             } else {
                 call.resolve();
             }
@@ -295,9 +300,9 @@ public class RadarPlugin extends Plugin {
     public void requestBeaconPermissions(PluginCall call) {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             PermissionState beaconPermissions;
-            String alias = "beacons";
+            String alias = BEACONS_PERMISSION;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-                alias = "beaconsAndroid12";
+                alias = BEACONS_PERMISSIONS_ANDROID_12;
             }
             beaconPermissions = getPermissionState(alias);
             if (PermissionState.GRANTED != beaconPermissions) {
@@ -317,11 +322,11 @@ public class RadarPlugin extends Plugin {
     @PermissionCallback
     @SuppressWarnings("unused")
     private void backgroundLocationPermsCallback(PluginCall call) {
-        PermissionState backgroundState = getPermissionState("backgroundLocation");
+        PermissionState backgroundState = getPermissionState(BACKGROUND_LOCATION_PERMISSION);
         if (PermissionState.GRANTED == backgroundState) {
-            PermissionState locationPermission = getPermissionState("location");
+            PermissionState locationPermission = getPermissionState(LOCATION_PERMISSION);
             if (PermissionState.GRANTED != locationPermission) {
-                requestPermissionForAlias("location", call, "locationPermsCallback");
+                requestPermissionForAlias(LOCATION_PERMISSION, call, "locationPermsCallback");
             } else {
                 call.resolve();
             }
@@ -336,7 +341,7 @@ public class RadarPlugin extends Plugin {
     @SuppressWarnings("unused")
     @PermissionCallback
     private void locationPermsCallback(PluginCall call) {
-        PermissionState locationPermission = getPermissionState("location");
+        PermissionState locationPermission = getPermissionState(LOCATION_PERMISSION);
         if (PermissionState.GRANTED == locationPermission) {
             call.resolve();
         } else {
@@ -346,9 +351,9 @@ public class RadarPlugin extends Plugin {
 
     @PermissionCallback
     private void beaconsPermsCallback(PluginCall call) {
-        String alias = "beacons";
+        String alias = BEACONS_PERMISSION;
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
-            alias = "beaconsAndroid12";
+            alias = BEACONS_PERMISSIONS_ANDROID_12;
         }
         PermissionState beaconPermissions = getPermissionState(alias);
         if (PermissionState.GRANTED == beaconPermissions) {

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -8,6 +8,8 @@ CAP_PLUGIN(RadarPlugin, "Radar",
     CAP_PLUGIN_METHOD(setMetadata, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(getLocationPermissionsStatus, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(requestLocationPermissions, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(getBeaconsPermissionStatus, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(requestBeaconPermissions, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(getLocation, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(trackOnce, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(startTrackingEfficient, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -126,6 +126,52 @@ public class RadarPlugin: CAPPlugin, RadarDelegate {
         }
     }
 
+    @objc func getBeaconsPermissionStatus(_ call: CAPPluginCall) {
+        getLocationPermissionsStatus(call)
+    }
+
+    @objc func requestBeaconPermissions(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            self.locationManager.requestWhenInUseAuthorization()
+            call.resolve()
+        }
+    }
+
+    @objc override public func checkPermissions(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            let authorizationStatus = CLLocationManager.authorizationStatus()
+            var location = "prompt"
+            var background = "prompt"
+            switch authorizationStatus {
+            case .notDetermined:
+                location = "prompt"
+                background = "prompt"
+            case .restricted, .denied:
+                location = "denied"
+                background = "denied"
+            case .authorizedAlways:
+                location = "granted"
+                background = "granted"
+            case .authorizedWhenInUse:
+                location = "granted"
+                background = "denied"
+            default:
+                location = "prompt"
+                background = "prompt"
+            }
+            call.resolve([
+                "location": location,
+                "backgroundLocation": background,
+                "beacons": location,
+                "beaconsAndroid12": location
+            ])
+        }
+    }
+
+    @objc override public func requestPermissions(_ call: CAPPluginCall) {
+        requestLocationPermissions(call)
+    }
+
     @objc func getLocation(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
             Radar.getLocation { (status: RadarStatus, location: CLLocation?, stopped: Bool) in

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -1,4 +1,5 @@
 import type { PluginListenerHandle } from '@capacitor/core';
+import type { PermissionState } from '@capacitor/core';
 
 export interface RadarPlugin {
   addListener(eventName: 'clientLocation', listenerFunc: (result: { location: Location, stopped: boolean, source: string }) => void): Promise<PluginListenerHandle> & PluginListenerHandle;
@@ -10,8 +11,12 @@ export interface RadarPlugin {
   setUserId(options: { userId: string }): void;
   setDescription(options: { description: string }): void;
   setMetadata(options: { metadata: object }): void;
+  checkPermissions(): Promise<PermissionStatus>;
+  requestPermissions(): Promise<PermissionStatus>;
   getLocationPermissionsStatus(): Promise<RadarLocationPermissionsCallback>;
   requestLocationPermissions(options: { background: boolean }): void;
+  getBeaconsPermissionStatus(): Promise<RadarBeaconsPermissionsCallback>;
+  requestBeaconsPermission(): void;
   getLocation(): Promise<RadarLocationCallback>;
   trackOnce(options?: { latitude?: number, longitude?: number, accuracy?: number }): Promise<RadarTrackCallback>;
   startTrackingEfficient(): void;
@@ -233,6 +238,10 @@ export interface RadarLocationPermissionsCallback {
   status: string;
 }
 
+export interface RadarBeaconsPermissionsCallback {
+  status: string;
+}
+
 export interface RadarAddress {
   latitude: number;
   longitude: number;
@@ -279,4 +288,11 @@ export interface RadarRouteDuration {
 export interface RadarTripEta {
   distance?: number;
   duration?: number;
+}
+
+export interface PermissionStatus {
+  location: PermissionState;
+  backgroundLocation: PermissionState;
+  beacons: PermissionState;
+  beaconsAndroid12: PermissionState;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -44,7 +44,7 @@ export class RadarPluginWeb extends WebPlugin implements RadarPlugin {
         throw this.unavailable('Permissions API not available in this browser.');
       } else {
         navigator.permissions.query({ name: 'geolocation' }).then((locationPermission) => {
-          navigator.permissions.query({ name: 'geolocation' }).then((bluetoothPermission) => {
+          navigator.permissions.query({ name: 'bluetooth' }).then((bluetoothPermission) => {
             resolve({
               location: locationPermission,
               backgroundLocation: locationPermission,

--- a/src/web.ts
+++ b/src/web.ts
@@ -43,14 +43,16 @@ export class RadarPluginWeb extends WebPlugin implements RadarPlugin {
       if (typeof navigator === 'undefined' || !navigator.permissions) {
         throw this.unavailable('Permissions API not available in this browser.');
       } else {
-        const locationPermission = await navigator.permissions.query({ name: 'geolocation' })
-        const bluetoothPermission = await navigator.permissions.query({ name: 'bluetooth' })
-        resolve({
-          location: locationPermission,
-          backgroundLocation: locationPermission,
-          beacons: bluetoothPermission,
-          beaconsAndroid12: bluetoothPermission
-        })
+        navigator.permissions.query({ name: 'geolocation' }).then((locationPermission) => {
+          navigator.permissions.query({ name: 'geolocation' }).then((bluetoothPermission) => {
+            resolve({
+              location: locationPermission,
+              backgroundLocation: locationPermission,
+              beacons: bluetoothPermission,
+              beaconsAndroid12: bluetoothPermission
+            })
+          });
+        });
       }
     });
   }

--- a/src/web.ts
+++ b/src/web.ts
@@ -67,7 +67,7 @@ export class RadarPluginWeb extends WebPlugin implements RadarPlugin {
 
       if (typeof navigator === 'undefined' || !navigator.permissions) {
         resolve({
-          status: 'UNKNOWN'
+          status: 'NOT_DETERMINED'
         });
       } else {
         navigator.permissions.query({ name: 'geolocation' }).then((result) => {
@@ -89,7 +89,7 @@ export class RadarPluginWeb extends WebPlugin implements RadarPlugin {
 
       if (typeof navigator === 'undefined' || !navigator.permissions) {
         resolve({
-          status: 'UNKNOWN'
+          status: 'NOT_DETERMINED'
         });
       } else {
         navigator.permissions.query({ name: 'bluetooth' }).then((result) => {


### PR DESCRIPTION
This fixes the permissions requests for capacitor on Android. I closely followed [the documentation](https://capacitorjs.com/docs/plugins/android) and verified the calls. The new methods also are more aligned with Capacitor and [web](https://developer.mozilla.org/en-US/docs/Web/API/Permissions_API) standards. 

This also adds checks for permissions needed for beacons to work on the SDK.

-----

Before doing this work, upon launching the Android example app, I got an error message `"status":"NOT_DETERMINED"`. With these changes, it now says `"status":"GRANTED_FOREGROUND"`. 