### PR TITLE
Add fraud to RadarUser object

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -107,6 +107,7 @@ export interface RadarUser {
   state?: RadarRegion;
   dma?: RadarRegion;
   postalCode?: RadarRegion;
+  fraud?: RadarFraud;
 }
 
 export interface RadarTrip {
@@ -280,4 +281,9 @@ export interface RadarRouteDuration {
 export interface RadarTripEta {
   distance?: number;
   duration?: number;
+}
+
+export interface RadarFraud {
+  proxy: boolean;
+  mocked: boolean;
 }


### PR DESCRIPTION
A Radar user object returned from a Track call contains a "fraud" object with two key/value pairs: `mocked` and `proxy`. We don't handle these now in the Capacitor plugin; this PR adds support for this fraud object and the two relevant properties.