### PR TITLE
[9522] Add workflow to automate SDK version bumps

### DIFF
--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -1,0 +1,105 @@
+# Bump Native SDK version numbers whenever a repository dispatch of a release
+# is received
+name: Bump Native SDKs
+on:
+  repository_dispatch:
+    types: ['ios-sdk-release', 'android-sdk-release']
+jobs:
+  update_android_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.client_payload.platform == "android"
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the build.gradle template file to its final destination
+      - name: Copy android/build.gradle template file
+        uses: canastro/copy-action@master
+        with:
+          source: "android/build.gradle.template"
+          target: "android/build.gradle"
+
+      # render the build.gradle template using the input sdk version
+      - name: Render radar-sdk-android release version onto android/build.gradle
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "android/build.gradle"
+
+      # copy the template file to its final destination
+      - name: Copy example/android/app/build.gradle template file
+        uses: canastro/copy-action@master
+        with:
+          source: "example/android/app/build.gradle.template"
+          target: "example/android/app/build.gradle"
+
+      # render the template using the input sdk version
+      - name: Render radar-sdk-android release version onto example/android/app/build.gradle
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "example/android/app/build.gradle"
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-android version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}
+  update_ios_sdk_version:
+    runs-on: ubuntu-latest
+    if: github.event.client_payload.platform == 'ios'
+    steps:
+      - name: Event Information
+        run: echo ${{ github.event.client_payload.release }}
+
+      # checkout the repo
+      - uses: actions/checkout@v2
+
+      # copy the podfile template to its final destination
+      - name: Copy ios/Cartfile.resolved template
+        uses: canastro/copy-action@master
+        with:
+          source: "ios/Podfile.template"
+          target: "ios/Podfile"
+
+      # render the podfile template with the sdk version
+      - name: Render radar-sdk-ios release version onto Cartfile template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "ios/Podfile"
+
+      # copy the podspec template to its final destination
+      - name: Copy the podspec template
+        uses: canastro/copy-action@master
+        with:
+          source: "CapacitorRadar.podspec.template"
+          target: "CapacitorRadar.podspec"
+
+      # render the podspec template with the sdk version
+      - name: Render radar-sdk-ios release version onto podspec template
+        uses: jayamanikharyono/jinja-action@v0.1
+        with:
+          data: version=${{ github.event.client_payload.release }}
+          path: "CapacitorRadar.podspec"
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
+
+      # open a pull request with the new sdk version
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v3
+        with:
+          title: Automated radar-sdk-ios version bump to ${{ github.event.client_payload.release }}
+          reviewers: radarlabs/eng
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/CapacitorRadar.podspec.template
+++ b/CapacitorRadar.podspec.template
@@ -1,0 +1,16 @@
+
+  Pod::Spec.new do |s|
+    package = JSON.parse(File.read(File.join(File.dirname(__FILE__), 'package.json')))
+    s.name = 'CapacitorRadar'
+    s.version = package['version']
+    s.summary = package['description']
+    s.license = package['license']
+    s.homepage = 'radarlabs/capacitor-radar'
+    s.author = 'Radar Labs, Inc.'
+    s.source = { :git => 'radarlabs/capacitor-radar', :tag => s.version.to_s }
+    s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
+    s.ios.deployment_target  = '12.0'
+    s.dependency 'Capacitor'
+    s.dependency 'RadarSDK', '~> {{ version }}'
+    s.static_framework = true
+  end

--- a/android/build.gradle.template
+++ b/android/build.gradle.template
@@ -1,0 +1,44 @@
+buildscript {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpath 'com.android.tools.build:gradle:7.0.3'
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 31
+    defaultConfig {
+        minSdkVersion 21
+        targetSdkVersion 31
+        versionCode 1
+        versionName '1.0'
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+    lintOptions {
+        abortOnError false
+    }
+}
+
+repositories {
+    google()
+    mavenCentral()
+}
+
+dependencies {
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation project(':capacitor-android')
+    testImplementation 'junit:junit:4.12'
+    androidTestImplementation 'com.android.support.test:runner:1.0.2'
+    androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
+    implementation 'io.radar:sdk:{{ version }}'
+}

--- a/example/android/app/build.gradle.template
+++ b/example/android/app/build.gradle.template
@@ -1,0 +1,52 @@
+apply plugin: 'com.android.application'
+
+android {
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    defaultConfig {
+        applicationId "io.ionic.starter"
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
+        versionCode 1
+        versionName "1.0"
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        aaptOptions {
+             // Files and dirs to omit from the packaged assets dir, modified to accommodate modern web apps.
+             // Default: https://android.googlesource.com/platform/frameworks/base/+/282e181b58cf72b6ca770dc7ca5f91f135444502/tools/aapt/AaptAssets.cpp#61
+            ignoreAssetsPattern '!.svn:!.git:!.ds_store:!*.scc:.*:!CVS:!thumbs.db:!picasa.ini:!*~'
+        }
+    }
+    buildTypes {
+        release {
+            minifyEnabled false
+            proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+        }
+    }
+}
+
+repositories {
+    flatDir{
+        dirs '../capacitor-cordova-android-plugins/src/main/libs', 'libs'
+    }
+}
+
+dependencies {
+    implementation fileTree(include: ['*.jar'], dir: 'libs')
+    implementation "androidx.appcompat:appcompat:$androidxAppCompatVersion"
+    implementation project(':capacitor-android')
+    testImplementation "junit:junit:$junitVersion"
+    androidTestImplementation "androidx.test.ext:junit:$androidxJunitVersion"
+    androidTestImplementation "androidx.test.espresso:espresso-core:$androidxEspressoCoreVersion"
+    implementation project(':capacitor-cordova-android-plugins')
+    implementation 'io.radar:sdk:{{ version}}'
+}
+
+apply from: 'capacitor.build.gradle'
+
+try {
+    def servicesJSON = file('google-services.json')
+    if (servicesJSON.text) {
+        apply plugin: 'com.google.gms.google-services'
+    }
+} catch(Exception e) {
+    logger.warn("google-services.json not found, google-services plugin not applied. Push Notifications won't work")
+}

--- a/ios/Podfile.template
+++ b/ios/Podfile.template
@@ -1,0 +1,13 @@
+platform :ios, '12.0'
+
+target 'Plugin' do
+  use_frameworks!
+  pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
+  pod 'RadarSDK', '~> {{ version }}'
+end
+
+target 'PluginTests' do
+  use_frameworks!
+  pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
+  pod 'RadarSDK', '~> {{ version }}'
+end


### PR DESCRIPTION
## Summary
Add Github Action that responds to `repository_dispatch` events and creates a PR for:
- updating `android/build.gradle` and `example/android/app/build.gradle` for Android SDK version bumps
- updating `CapacitorRadar.podspec` and `ios/Podfile` for iOS SDK version bumps
- updating package.json and package-lock.json for both any version bumps

Note: Decided to ignore `ios/Podfile.lock` since official [Capacitor plugins](https://github.com/ionic-team/capacitor-plugins) seem to not even check that into source control. This might be removed from the repo + added to `.gitignore` in the near future.