### PR TITLE
Update circleci to convenience images.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   android:
     working_directory: ~/capacitor-radar
     docker:
-      - image: circleci/android:api-28-node
+      - image: cimg/android:2022.04.1-node
     steps:
       - checkout:
           path: ~/capacitor-radar


### PR DESCRIPTION
Uses new CircleCI convenience images: https://circleci.com/developer/images?imageType=docker.