### PR TITLE
[Automation] Triage Version-bump Github Action

### DIFF
--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -15,6 +15,10 @@ jobs:
       # checkout the repo
       - uses: actions/checkout@v2
 
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
+
       # copy the build.gradle template file to its final destination
       - name: Copy android/build.gradle template file
         uses: canastro/copy-action@master
@@ -43,10 +47,6 @@ jobs:
           data: version=${{ github.event.client_payload.release }}
           path: 'example/android/app/build.gradle'
 
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
-
       # open a pull request with the new sdk version
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -63,6 +63,10 @@ jobs:
 
       # checkout the repo
       - uses: actions/checkout@v2
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }}
 
       # copy the podfile template to its final destination
       - name: Copy ios/Cartfile.resolved template
@@ -91,10 +95,6 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: 'CapacitorRadar.podspec'
-
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
 
       # open a pull request with the new sdk version
       - name: Create Pull Request

--- a/.github/workflows/bump-native-sdks.yml
+++ b/.github/workflows/bump-native-sdks.yml
@@ -15,10 +15,6 @@ jobs:
       # checkout the repo
       - uses: actions/checkout@v2
 
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
-
       # copy the build.gradle template file to its final destination
       - name: Copy android/build.gradle template file
         uses: canastro/copy-action@master
@@ -47,6 +43,10 @@ jobs:
           data: version=${{ github.event.client_payload.release }}
           path: 'example/android/app/build.gradle'
 
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }} --commit-hooks false --git-tag-version false
+
       # open a pull request with the new sdk version
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3
@@ -63,10 +63,6 @@ jobs:
 
       # checkout the repo
       - uses: actions/checkout@v2
-
-      # Update package.json to latest version
-      - name: Update package.json to latest
-        run: npm version ${{ github.event.client_payload.release }}
 
       # copy the podfile template to its final destination
       - name: Copy ios/Cartfile.resolved template
@@ -95,6 +91,10 @@ jobs:
         with:
           data: version=${{ github.event.client_payload.release }}
           path: 'CapacitorRadar.podspec'
+
+      # Update package.json to latest version
+      - name: Update package.json to latest
+        run: npm version ${{ github.event.client_payload.release }} --commit-hooks false --git-tag-version false
 
       # open a pull request with the new sdk version
       - name: Create Pull Request


### PR DESCRIPTION
## Summary
The `npm version` in the auto-version bump Github action was failing because, by default, `npm version` makes a commit and creates a tag. 

Fortunately, these [options can be bypassed](https://docs.npmjs.com/cli/v7/commands/npm-version#git-tag-version) so these changes can just be included with the PR's changes.