### PR TITLE
Upgrade radar-sdk-js to 3.5.0

### DIFF
--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -53,11 +53,11 @@
       }
     },
     "..": {
-      "version": "3.5.2",
+      "version": "3.5.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@capacitor/core": "^3.0.1",
-        "radar-sdk-js": "^3.1.1"
+        "radar-sdk-js": "^3.5.0"
       },
       "devDependencies": {
         "@capacitor/android": "^3.0.1",
@@ -24948,7 +24948,7 @@
         "@capacitor/android": "^3.0.1",
         "@capacitor/core": "^3.0.1",
         "@capacitor/ios": "^3.0.1",
-        "radar-sdk-js": "^3.1.1",
+        "radar-sdk-js": "^3.5.0",
         "typescript": "^4.4.4"
       }
     },

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -53,7 +53,7 @@
       }
     },
     "..": {
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@capacitor/core": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-radar",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-radar",
-      "version": "3.5.3",
+      "version": "3.5.4",
       "license": "Apache-2.0",
       "dependencies": {
         "@capacitor/core": "^3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@capacitor/core": "^3.0.1",
-        "radar-sdk-js": "^3.1.1"
+        "radar-sdk-js": "^3.5.0"
       },
       "devDependencies": {
         "@capacitor/android": "^3.0.1",
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/radar-sdk-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.2.1.tgz",
-      "integrity": "sha512-tXyUIwUY1ly10R0V83yP1ufbR5E9b0zWzq1iWRx17hXe1Gh/HTpqPPFtjLO/+hLILNA+1FtGhFjgyVbQ26+hWA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.5.0.tgz",
+      "integrity": "sha512-KIRGSN4EU45lzjcvoiAYyclONoHRgpHyJhBaNXVHOFZWY/SuwMqHtiUOSI4sKPtD/TfeMht8PIN9FYxAmzttQQ=="
     },
     "node_modules/tslib": {
       "version": "2.3.1",
@@ -94,9 +94,9 @@
       "requires": {}
     },
     "radar-sdk-js": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.2.1.tgz",
-      "integrity": "sha512-tXyUIwUY1ly10R0V83yP1ufbR5E9b0zWzq1iWRx17hXe1Gh/HTpqPPFtjLO/+hLILNA+1FtGhFjgyVbQ26+hWA=="
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/radar-sdk-js/-/radar-sdk-js-3.5.0.tgz",
+      "integrity": "sha512-KIRGSN4EU45lzjcvoiAYyclONoHRgpHyJhBaNXVHOFZWY/SuwMqHtiUOSI4sKPtD/TfeMht8PIN9FYxAmzttQQ=="
     },
     "tslib": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "license": "Apache-2.0",
   "dependencies": {
     "@capacitor/core": "^3.0.1",
-    "radar-sdk-js": "^3.1.1"
+    "radar-sdk-js": "^3.5.0"
   },
   "devDependencies": {
     "@capacitor/android": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-radar",
-  "version": "3.5.3",
+  "version": "3.5.4",
   "description": "Capacitor plugin for Radar, the leading geofencing and location tracking platform",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",


### PR DESCRIPTION
Also bumps `capacitor-radar` version to enable us to push out a new release when we're ready (Instructions [here](https://www.notion.so/radarlabs/How-to-release-the-Capacitor-SDK-8bc2e7a5720b4c0a896e324e70e6841c))