### PR TITLE
added getLogLevel

### DIFF
--- a/android/src/main/java/io/radar/capacitor/RadarPlugin.java
+++ b/android/src/main/java/io/radar/capacitor/RadarPlugin.java
@@ -181,6 +181,34 @@ public class RadarPlugin extends Plugin {
     }
 
     @PluginMethod()
+    public void getLogLevel(PluginCall call) {
+        Radar.RadarLogLevel currentLogLevel = Radar.getLogLevel();
+        String levelString = "";
+
+        switch (currentLogLevel) {
+            case ERROR:
+                levelString = "error";
+                break;
+            case WARNING:
+                levelString = "warning";
+                break;
+            case INFO:
+                levelString = "info";
+                break;
+            case DEBUG:
+                levelString = "debug";
+                break;
+            case NONE:
+                levelString = "none";
+                break;
+        }
+
+        JSObject ret = new JSObject();
+        ret.put("level", levelString);
+        call.resolve(ret);
+    }
+
+    @PluginMethod()
     public void setUserId(PluginCall call) {
         String userId = call.getString("userId");
         Radar.setUserId(userId);

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -4,6 +4,7 @@
 CAP_PLUGIN(RadarPlugin, "Radar",
     CAP_PLUGIN_METHOD(initialize, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(setLogLevel, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(getLogLevel, CAPPluginReturnPromise); 
     CAP_PLUGIN_METHOD(setUserId, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(getUserId, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(setDescription, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -111,6 +111,28 @@ public class RadarPlugin: CAPPlugin, RadarDelegate {
         }
     }
 
+    @objc func getLogLevel(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            let currentLogLevel = Radar.getLogLevel()
+            var levelString = ""
+
+            switch currentLogLevel {
+                case .error:
+                    levelString = "error"
+                case .warning:
+                    levelString = "warning"
+                case .info:
+                levelString = "info"
+                case .debug:
+                    levelString = "debug"
+                case .none:
+                    levelString = "none"
+            }
+
+            call.resolve(["level": levelString])
+        }
+    } 
+
     @objc func getUserId(_ call: CAPPluginCall) {
         DispatchQueue.main.async {
             call.resolve([

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -8,6 +8,7 @@ export interface RadarPlugin {
   addListener(eventName: 'log', listenerFunc: (result: { message: string }) => void): Promise<PluginListenerHandle> & PluginListenerHandle;
   initialize(options: { publishableKey: string }): void;
   setLogLevel(options: { level: string }): void;
+  getLogLevel():Promise<object>;
   setUserId(options: { userId?: string }): void;
   getUserId(): Promise<object>,
   setDescription(options: { description?: string }): void;


### PR DESCRIPTION
Able to get logging from the example app after pointing capacitor to appropriate native sdk

IOS: <img width="378" alt="Screenshot 2023-09-14 at 11 59 50 AM" src="https://github.com/radarlabs/capacitor-radar/assets/139801512/c02df9c6-56e2-4768-8e83-0b8258138d62">
Android <img width="384" alt="Screenshot 2023-09-14 at 12 55 48 PM" src="https://github.com/radarlabs/capacitor-radar/assets/139801512/43c9251a-0c5d-4ee3-92d8-22493157e7bc">
