### PR TITLE
Adding stopTrackingVerified method

### DIFF
--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -29,6 +29,7 @@ export interface RadarPlugin {
   startTrackingCustom(options: { options: RadarTrackingOptions}): void;
   mockTracking(options: { origin: Location, destination: Location, mode: RadarRouteMode, steps: number, interval: number }): void;
   stopTracking(): void;
+  stopTrackingVerified(): void;
   isTracking(): Promise<RadarTrackingStatus>;
   getTrackingOptions(): Promise<RadarTrackingOptions>,
   setForegroundServiceOptions(options: { options: RadarTrackingOptionsForegroundService }): void;


### PR DESCRIPTION
I added the missing stopTrackingVerified method to the capacitor-radar SDK. Previously we couldn't access it using typescript.