### PR TITLE
bump radar native sdk versions to 3.18.+

### DIFF
--- a/CapacitorRadar.podspec
+++ b/CapacitorRadar.podspec
@@ -11,6 +11,6 @@
     s.source_files = 'ios/Plugin/**/*.{swift,h,m,c,cc,mm,cpp}'
     s.ios.deployment_target  = '12.0'
     s.dependency 'Capacitor'
-    s.dependency 'RadarSDK', '~> 3.16.0'
+    s.dependency 'RadarSDK', '~> 3.18.3'
     s.static_framework = true
   end

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -41,6 +41,6 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'io.radar:sdk:3.16.0'
+    implementation 'io.radar:sdk:3.18.3'
 }
 

--- a/android/src/main/java/io/radar/capacitor/RadarPlugin.java
+++ b/android/src/main/java/io/radar/capacitor/RadarPlugin.java
@@ -172,7 +172,7 @@ public class RadarPlugin extends Plugin {
         String publishableKey = call.getString("publishableKey");
         SharedPreferences.Editor editor = this.getContext().getSharedPreferences("RadarSDK", Context.MODE_PRIVATE).edit();
         editor.putString("x_platform_sdk_type", "Capacitor");
-        editor.putString("x_platform_sdk_version", "3.12.0");
+        editor.putString("x_platform_sdk_version", "3.13.0");
         editor.apply();
         Radar.initialize(this.getContext(), publishableKey);
         call.resolve();
@@ -416,6 +416,16 @@ public class RadarPlugin extends Plugin {
                 }
             }
         });
+    }
+
+    @PluginMethod()
+    public void setExpectedJurisdiction(final PluginCall call) {
+        String countryCode = call.getString("countryCode");
+        String stateCode = call.getString("stateCode");
+
+        // TODO: when Android Sdk fixes this method to be static, uncomment
+        // Radar.setExpectedJurisdiction(countryCode, stateCode);
+        call.resolve();
     }
 
     @PluginMethod()

--- a/example/ios/App/Podfile.lock
+++ b/example/ios/App/Podfile.lock
@@ -8,12 +8,12 @@ PODS:
     - Capacitor
   - CapacitorKeyboard (6.0.1):
     - Capacitor
-  - CapacitorRadar (3.12.0):
+  - CapacitorRadar (3.13.0):
     - Capacitor
-    - RadarSDK (~> 3.16.0)
+    - RadarSDK (~> 3.18.3)
   - CapacitorStatusBar (6.0.0):
     - Capacitor
-  - RadarSDK (3.16.0)
+  - RadarSDK (3.18.3)
 
 DEPENDENCIES:
   - "Capacitor (from `../../node_modules/@capacitor/ios`)"
@@ -50,9 +50,9 @@ SPEC CHECKSUMS:
   CapacitorCordova: be703980ca797f847c3356f78fa175d21c8330c2
   CapacitorHaptics: 9ebc9363f0e9b8eb4295088a0b474530acf1859b
   CapacitorKeyboard: 5f32a712adf41e07a61caafb82cf29fb6d8ba123
-  CapacitorRadar: 2958b8309a0e0488c4d6bf7e99a7e0f6d7013f3a
+  CapacitorRadar: 5440fa327f8d2f2931a913385ca4f9a4b370744a
   CapacitorStatusBar: 2e4369f99166125435641b1908d05f561eaba6f6
-  RadarSDK: 9f7e4fd1e45d98c7ff426800969108a74e87ee6d
+  RadarSDK: a27e5ffc832737dd5923ee2f826d302001c65c70
 
 PODFILE CHECKSUM: 508e95281399d4582fa695426a6beddb6f655471
 

--- a/example/package-lock.json
+++ b/example/package-lock.json
@@ -53,7 +53,7 @@
       }
     },
     "..": {
-      "version": "3.12.0",
+      "version": "3.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@capacitor/core": "^4.0.0",

--- a/ios/Plugin/Plugin.m
+++ b/ios/Plugin/Plugin.m
@@ -17,6 +17,7 @@ CAP_PLUGIN(RadarPlugin, "Radar",
     CAP_PLUGIN_METHOD(trackOnce, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(trackVerified, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(getVerifiedLocationToken, CAPPluginReturnPromise);
+    CAP_PLUGIN_METHOD(setExpectedJurisdiction, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(startTrackingVerified, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(startTrackingEfficient, CAPPluginReturnPromise);
     CAP_PLUGIN_METHOD(startTrackingResponsive, CAPPluginReturnPromise);

--- a/ios/Plugin/Plugin.swift
+++ b/ios/Plugin/Plugin.swift
@@ -70,7 +70,7 @@ public class RadarPlugin: CAPPlugin, RadarDelegate, RadarVerifiedDelegate {
                 return
             }
             UserDefaults.standard.set("Capacitor", forKey: "radar-xPlatformSDKType")
-            UserDefaults.standard.set("3.12.0", forKey: "radar-xPlatformSDKVersion")
+            UserDefaults.standard.set("3.13.0", forKey: "radar-xPlatformSDKVersion")
             Radar.initialize(publishableKey: publishableKey)
             call.resolve()
         }
@@ -311,6 +311,16 @@ public class RadarPlugin: CAPPlugin, RadarDelegate, RadarVerifiedDelegate {
                     call.reject(Radar.stringForStatus(status))
                 }
             }
+        }
+    }
+
+    @objc func setExpectedJurisdiction(_ call: CAPPluginCall) {
+        DispatchQueue.main.async {
+            let countryCode = call.getString("countryCode")
+            let stateCode = call.getString("stateCode")
+
+            Radar.setExpectedJurisdiction(countryCode: countryCode, stateCode: stateCode)
+            call.resolve()
         }
     }
 

--- a/ios/Podfile
+++ b/ios/Podfile
@@ -3,11 +3,11 @@ platform :ios, '12.0'
 target 'Plugin' do
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
-  pod 'RadarSDK', '~> 3.16.0'
+  pod 'RadarSDK', '~> 3.18.3'
 end
 
 target 'PluginTests' do
   use_frameworks!
   pod 'Capacitor', :path => '../node_modules/@capacitor/ios'
-  pod 'RadarSDK', '~> 3.16.0'
+  pod 'RadarSDK', '~> 3.18.3'
 end

--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -2,11 +2,11 @@ PODS:
   - Capacitor (4.8.2):
     - CapacitorCordova
   - CapacitorCordova (3.7.0)
-  - RadarSDK (3.10.1)
+  - RadarSDK (3.18.3)
 
 DEPENDENCIES:
   - "Capacitor (from `../node_modules/@capacitor/ios`)"
-  - RadarSDK (~> 3.10.0)
+  - RadarSDK (~> 3.18.3)
 
 SPEC REPOS:
   trunk:
@@ -20,8 +20,8 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   Capacitor: 67c335fe9ce677e3f92b63e7f4b8df52e2ca3bbb
   CapacitorCordova: e6b42a8e8d5986c1eb8f02ac0be205fafc32ac33
-  RadarSDK: be34556e3ce0ae7adccf3212c03a13ed464f4289
+  RadarSDK: a27e5ffc832737dd5923ee2f826d302001c65c70
 
-PODFILE CHECKSUM: 41ad7c5ac0bd8085a22049001bf05a1daee707d8
+PODFILE CHECKSUM: 5a75207e928cb7f868e2639fcf346ee55ec030fb
 
 COCOAPODS: 1.15.2

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "capacitor-radar",
-  "version": "3.12.0",
+  "version": "3.13.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "capacitor-radar",
-      "version": "3.12.0",
+      "version": "3.13.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@capacitor/core": "^4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "capacitor-radar",
-  "version": "3.12.1",
+  "version": "3.13.0",
   "description": "Capacitor plugin for Radar, the leading geofencing and location tracking platform",
   "main": "dist/esm/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -22,6 +22,8 @@ export interface RadarPlugin {
   trackOnce(options?: Location | { desiredAccuracy: RadarTrackingOptionsDesiredAccuracy, beacons: boolean}): Promise<RadarTrackCallback>;
   trackVerified(options?: { beacons?: boolean }): Promise<RadarTrackCallback>;
   getVerifiedLocationToken(): Promise<RadarTrackTokenCallback>;
+  // TODO: when Android Sdk fixes this method to be static, uncomment
+  // setExpectedJurisdiction(options?: { countryCode: string, stateCode: string }): void;
   startTrackingVerified(options: { token?: boolean, interval: number, beacons: boolean }): void;
   startTrackingEfficient(): void;
   startTrackingResponsive(): void;
@@ -286,6 +288,7 @@ export interface RadarGeofence {
   tag?: string;
   externalId?: string;
   metadata?: object;
+  operatingHours?: object;
 }
 
 export interface RadarBeacon {
@@ -464,13 +467,13 @@ export interface RadarTrackingOptionsForegroundService {
 }
 
 export interface RadarTripOptions {
-   externalId: string;
-   metadata?: object;
-   destinationGeofenceTag?: string;
-   destinationGeofenceExternalId?: string;
-   mode?: RadarRouteMode;
-   scheduledArrivalAt?: Date;
-   approachingThreshold?: number
+  externalId: string;
+  metadata?: object;
+  destinationGeofenceTag?: string;
+  destinationGeofenceExternalId?: string;
+  mode?: RadarRouteMode;
+  scheduledArrivalAt?: Date;
+  approachingThreshold?: number
 }
 
 export type RadarTripStatus = 

--- a/src/web.ts
+++ b/src/web.ts
@@ -132,6 +132,10 @@ export class RadarPluginWeb extends WebPlugin implements RadarPlugin {
     // not implemented
   }
 
+  setExpectedJurisdiction(options?: { countryCode: string; stateCode: string; }): void {
+    // not implemented
+  }
+
   startTrackingVerified(options: { token?: boolean, interval: number, beacons: boolean }): void {
     // not implemented
   }


### PR DESCRIPTION
does not include RadarMotion due to requiring pod set up with plugin config, TODO in another ticket.
does not include notification conversions due to missing radar initialization option fromDict function, TODO in another ticket.
does not include setExpectedJurisdiction due to Android function missing `@JvmStatic` tag, uncallable from capacitor, TODO in another ticket. (fully implemented, not exposed in typescript interface)

updates native versions to 3.18.+ which include bug fixes and behavioral improvements. 